### PR TITLE
add v3.9 and v3.10 indexes

### DIFF
--- a/apkindex.list
+++ b/apkindex.list
@@ -108,3 +108,15 @@ alpine/v3.9/main/ppc64le/APKINDEX.tar.gz
 alpine/v3.9/main/s390x/APKINDEX.tar.gz
 alpine/v3.9/main/x86/APKINDEX.tar.gz
 alpine/v3.9/main/x86_64/APKINDEX.tar.gz
+alpine/v3.10/community/aarch64/APKINDEX.tar.gz
+alpine/v3.10/community/armhf/APKINDEX.tar.gz
+alpine/v3.10/community/ppc64le/APKINDEX.tar.gz
+alpine/v3.10/community/s390x/APKINDEX.tar.gz
+alpine/v3.10/community/x86/APKINDEX.tar.gz
+alpine/v3.10/community/x86_64/APKINDEX.tar.gz
+alpine/v3.10/main/aarch64/APKINDEX.tar.gz
+alpine/v3.10/main/armhf/APKINDEX.tar.gz
+alpine/v3.10/main/ppc64le/APKINDEX.tar.gz
+alpine/v3.10/main/s390x/APKINDEX.tar.gz
+alpine/v3.10/main/x86/APKINDEX.tar.gz
+alpine/v3.10/main/x86_64/APKINDEX.tar.gz

--- a/apkindex.list
+++ b/apkindex.list
@@ -96,3 +96,15 @@ alpine/v3.8/main/ppc64le/APKINDEX.tar.gz
 alpine/v3.8/main/s390x/APKINDEX.tar.gz
 alpine/v3.8/main/x86/APKINDEX.tar.gz
 alpine/v3.8/main/x86_64/APKINDEX.tar.gz
+alpine/v3.9/community/aarch64/APKINDEX.tar.gz
+alpine/v3.9/community/armhf/APKINDEX.tar.gz
+alpine/v3.9/community/ppc64le/APKINDEX.tar.gz
+alpine/v3.9/community/s390x/APKINDEX.tar.gz
+alpine/v3.9/community/x86/APKINDEX.tar.gz
+alpine/v3.9/community/x86_64/APKINDEX.tar.gz
+alpine/v3.9/main/aarch64/APKINDEX.tar.gz
+alpine/v3.9/main/armhf/APKINDEX.tar.gz
+alpine/v3.9/main/ppc64le/APKINDEX.tar.gz
+alpine/v3.9/main/s390x/APKINDEX.tar.gz
+alpine/v3.9/main/x86/APKINDEX.tar.gz
+alpine/v3.9/main/x86_64/APKINDEX.tar.gz


### PR DESCRIPTION
mirrors.alpinelinux.org is missing v3.9 status. Adding indexes should fix this.