### PR TITLE
Add 3.12 branches to apkindex

### DIFF
--- a/apkindex.list
+++ b/apkindex.list
@@ -142,3 +142,17 @@ alpine/v3.11/main/ppc64le/APKINDEX.tar.gz
 alpine/v3.11/main/s390x/APKINDEX.tar.gz
 alpine/v3.11/main/x86/APKINDEX.tar.gz
 alpine/v3.11/main/x86_64/APKINDEX.tar.gz
+alpine/v3.12/community/aarch64/APKINDEX.tar.gz
+alpine/v3.12/community/armhf/APKINDEX.tar.gz
+alpine/v3.12/community/armv7/APKINDEX.tar.gz
+alpine/v3.12/community/ppc64le/APKINDEX.tar.gz
+alpine/v3.12/community/s390x/APKINDEX.tar.gz
+alpine/v3.12/community/x86/APKINDEX.tar.gz
+alpine/v3.12/community/x86_64/APKINDEX.tar.gz
+alpine/v3.12/main/aarch64/APKINDEX.tar.gz
+alpine/v3.12/main/armhf/APKINDEX.tar.gz
+alpine/v3.12/main/armv7/APKINDEX.tar.gz
+alpine/v3.12/main/ppc64le/APKINDEX.tar.gz
+alpine/v3.12/main/s390x/APKINDEX.tar.gz
+alpine/v3.12/main/x86/APKINDEX.tar.gz
+alpine/v3.12/main/x86_64/APKINDEX.tar.gz


### PR DESCRIPTION
I hope this is what's generating https://mirrors.alpinelinux.org/ (it's not explicit), but it'd be great to get 3.12 data being tracked.

The other quality of life enhancement which looks non-trivial for someone without lua experience is providing a numeric-string sort on the versions... 

On the website the datasets go: 
- ...
- v3.1
- v3.10
- v3.11
- v3.2
- ...